### PR TITLE
Compatibility with Wolvin's Prop Hunt Extended

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ node('linux && amd64 && docker') {
   docker.image('icedream/gmad:latest').inside {
     ansiColor('xterm') {
       checkout scm
-      sh 'gmad create -folder . -out icedream-tauntmenu.gma'
+      sh 'gmad_linux create -folder . -out icedream-tauntmenu.gma'
       archive '*.gma'
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,9 @@
+node('linux && amd64 && docker') {
+  docker.image('icedream/gmad:latest').inside {
+    ansiColor('xterm') {
+      git checkout
+      sh 'gmad create -folder . -out icedream-tauntmenu.gma'
+      archive '*.gma'
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node('linux && amd64 && docker') {
   docker.image('icedream/gmad:latest').inside {
     ansiColor('xterm') {
-      git checkout
+      checkout scm
       sh 'gmad create -folder . -out icedream-tauntmenu.gma'
       archive '*.gma'
     }

--- a/addon.json
+++ b/addon.json
@@ -18,6 +18,7 @@
 		"*.txt",
 		"*.gma",
 		".git*",
+		"Jenkinsfile",
 		"logo.*"
 	]
 }


### PR DESCRIPTION
PHE uses its own configuration object from which we can derive all sound paths and taunt playback tweaks. The question in this case is whether PHE will change this still at some point. Hopefully not.